### PR TITLE
Use high DPI Pixmaps

### DIFF
--- a/src/fractgen.cc
+++ b/src/fractgen.cc
@@ -31,6 +31,7 @@
 int main(int argc, char *argv[])
 {
    QApplication application(argc, argv);
+   application.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
    QTranslator applicationTranslator;
    if(!applicationTranslator.load("fractgen_" + QLocale::system().name())) {
       applicationTranslator.load("fractgen_" + QLocale::system().name(),


### PR DESCRIPTION
Makes icons on buttons in dialogs sharp on a high DPI screen.